### PR TITLE
settings supports keyword

### DIFF
--- a/preferences.js
+++ b/preferences.js
@@ -19,6 +19,24 @@ define(function main(require, exports, module) {
     prefs.definePreference('additional-flags', 'string', '');
     prefs.definePreference('configurations', 'array', [
         {
+            'name': 'npm run',
+            'cwd': '',
+            'flags': '',
+            'type': 'npm',
+            'target': '{project_root}/package.json',
+            'debug': false
+        },
+
+        {
+            'name': 'gulp task',
+            'cwd': '',
+            'flags': '',
+            'type': 'gulp',
+            'target': '{project_root}/gulpfile.js',
+            'debug': false
+        },
+
+        {
             'name': 'nodejs process sample',
             'cwd': '',
             'flags': '',
@@ -26,6 +44,7 @@ define(function main(require, exports, module) {
             'target': extension_utils.getModulePath(module, 'tests/hello.js'),
             'debug': false
         },
+
         {
             'name': 'http server sample',
             'cwd': '',

--- a/src/keywords_parser.js
+++ b/src/keywords_parser.js
@@ -1,0 +1,52 @@
+/*global define, brackets */
+
+'use strict';
+
+/**
+ * parse key words in settings
+ *
+ * keywords :
+ *   {project_root} - the full path of the root folder opened in Brackets now
+ *   {file} - the full path of a folder contains the current file
+ *   ...
+ */
+define(function main(require, exports) {
+    var project_manager = brackets.getModule('project/ProjectManager');
+    var editor_manager = brackets.getModule('editor/EditorManager');
+
+    var parsers = {
+        project_root: function () {
+            return project_manager.getProjectRoot().fullPath.replace(/(\\|\/)$/, '');
+        },
+        file: function () {
+            var ae = editor_manager.getActiveEditor();
+
+            return ae ? ae.getFile().parentPath.replace(/(\\|\/)$/, '') : '';
+        }
+    };
+
+    var pattern = /\{[a-z0-9_]+\}/g;
+
+    /**
+     * parser keywords
+     * @param {string} value - a value of a settings' item
+     * @return {string} the value after replacing keywords
+     */
+    exports.parse = function (value) {
+        var kws = value.match(pattern) || [];
+        kws = kws.map(function (d) {
+            var kw = d.replace(/\{|\}/g, '');
+            var pf = parsers[kw];
+            return pf ? pf() : d;
+        });
+
+        var result = [], parts = value.split(pattern);
+        for (var i=0; i<parts.length; i++) {
+            result.push(parts[i]);
+            result.push(kws[i] || '');
+        }
+
+        return result.join('');
+    }
+
+});

--- a/src/runner_panel.js
+++ b/src/runner_panel.js
@@ -32,6 +32,8 @@ define(function main(require, exports, module) {
     var runner_menu_template = require('text!../templates/runner_menu.html');
     var utils = require('../utils');
 
+    var keywords_parser = require('./keywords_parser');
+
     var $dropdown = null;
     var $runner_panel = $(null);
     var panel = null;
@@ -400,6 +402,11 @@ define(function main(require, exports, module) {
                 flags: $(this).attr('flags')
             };
         }
+
+        // parse keywords
+        run_configuration.target = keywords_parser.parse(run_configuration.target);
+        run_configuration.cwd = keywords_parser.parse(run_configuration.cwd);
+
         var selected_run_configuration = $runner_panel.find('.nodejs-integration-tab-pane.active .run-configuration-dropdown-toggle');
         selected_run_configuration.find('.type')
             .removeClass('node')


### PR DESCRIPTION
target and cwd support using {project_root} keyword
default preferences add "npm run" and "gulp task" two runners